### PR TITLE
Fix duplicate reloads in home stats

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -94,16 +95,31 @@ class _InicioPageState extends ConsumerState<InicioPage> {
 
     await Future.wait(futures);
 
-    // Actualiza los estados locales
+    // Actualiza los estados locales solo si hay cambios
     if (!mounted) return;
     final elapsed = stopwatch.elapsedMilliseconds;
     print("Tiempo: ${elapsed}ms");
-    setState(() {
-      _grantedPermissions = grantedPermissions;
-      _dataPointsSteps = dataPointsSteps;
-      _dataPointsWorkout = dataPointsWorkout;
-      _entrenamientosMrFit = entrenamientosMrFit;
-    });
+
+    final bool permissionsChanged =
+        !mapEquals(_grantedPermissions, grantedPermissions);
+    final bool stepsChanged =
+        !listEquals(_dataPointsSteps, dataPointsSteps);
+    final bool workoutsChanged =
+        !listEquals(_dataPointsWorkout, dataPointsWorkout);
+    final bool entrenamientosChanged =
+        !listEquals(_entrenamientosMrFit, entrenamientosMrFit);
+
+    if (permissionsChanged ||
+        stepsChanged ||
+        workoutsChanged ||
+        entrenamientosChanged) {
+      setState(() {
+        _grantedPermissions = grantedPermissions;
+        _dataPointsSteps = dataPointsSteps;
+        _dataPointsWorkout = dataPointsWorkout;
+        _entrenamientosMrFit = entrenamientosMrFit;
+      });
+    }
   }
 
   @override
@@ -197,7 +213,12 @@ class _InicioPageState extends ConsumerState<InicioPage> {
                 selectedDate: _selectedDate,
                 grantedPermissions: _grantedPermissions,
                 onDateSelected: (date) {
-                  if (date.isAfter(DateTime.now())) return;
+                  if (date.isAfter(DateTime.now()) ||
+                      date.year == _selectedDate.year &&
+                          date.month == _selectedDate.month &&
+                          date.day == _selectedDate.day) {
+                    return;
+                  }
                   setState(() {
                     _selectedDate = date;
                     _clearDailyStatsData();
@@ -219,8 +240,14 @@ class _InicioPageState extends ConsumerState<InicioPage> {
                   if (state is CalendarWidgetStateBase) {
                     state.jumpToToday();
                   }
+                  final today = DateTime.now();
+                  if (today.year == _selectedDate.year &&
+                      today.month == _selectedDate.month &&
+                      today.day == _selectedDate.day) {
+                    return;
+                  }
                   setState(() {
-                    _selectedDate = DateTime.now();
+                    _selectedDate = today;
                     _clearDailyStatsData();
                   });
                   final usuario = ref.read(usuarioProvider);

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -40,16 +40,18 @@ class _InicioPageState extends ConsumerState<InicioPage> {
   List<HealthDataPoint> _dataPointsWorkout = [];
   List<Map<String, dynamic>> _entrenamientosMrFit = [];
 
+  void _clearDailyStatsData() {
+    _grantedPermissions = {};
+    _dataPointsSteps = [];
+    _dataPointsWorkout = [];
+    _entrenamientosMrFit = [];
+  }
+
   // Obtiene y actualiza los datos necesarios para dailyStatsWidget según el día seleccionado.
   Future<void> _fetchAndSetDailyStatsData(Usuario usuario, DateTime day) async {
     // Medimos el tiempo de ejecución para monitorear el performance de la función.
     final stopwatch = Stopwatch()..start();
 
-    setState(() {
-      _dataPointsSteps = [];
-      _dataPointsWorkout = [];
-      _entrenamientosMrFit = [];
-    });
 
     final Map<String, bool> grantedPermissions = {};
     for (var key in usuario.healthDataTypesString.keys) {
@@ -156,7 +158,10 @@ class _InicioPageState extends ConsumerState<InicioPage> {
       return;
     }
 
-    setState(() => _selectedDate = nextDate);
+    setState(() {
+      _selectedDate = nextDate;
+      _clearDailyStatsData();
+    });
     final usuario = ref.read(usuarioProvider);
     _fetchAndSetDailyStatsData(usuario, nextDate);
     _reloadCalendarIfInCurrentWeek(nextDate);
@@ -193,7 +198,10 @@ class _InicioPageState extends ConsumerState<InicioPage> {
                 grantedPermissions: _grantedPermissions,
                 onDateSelected: (date) {
                   if (date.isAfter(DateTime.now())) return;
-                  setState(() => _selectedDate = date);
+                  setState(() {
+                    _selectedDate = date;
+                    _clearDailyStatsData();
+                  });
                   final usuario = ref.read(usuarioProvider);
                   _fetchAndSetDailyStatsData(usuario, date);
                 },
@@ -211,7 +219,10 @@ class _InicioPageState extends ConsumerState<InicioPage> {
                   if (state is CalendarWidgetStateBase) {
                     state.jumpToToday();
                   }
-                  setState(() => _selectedDate = DateTime.now());
+                  setState(() {
+                    _selectedDate = DateTime.now();
+                    _clearDailyStatsData();
+                  });
                   final usuario = ref.read(usuarioProvider);
                   _fetchAndSetDailyStatsData(usuario, _selectedDate);
                 },
@@ -234,6 +245,7 @@ class _InicioPageState extends ConsumerState<InicioPage> {
                     child: RefreshIndicator(
                       key: _refreshKey,
                       onRefresh: () async {
+                        setState(_clearDailyStatsData);
                         _reloadCalendarIfInCurrentWeek(_selectedDate);
                         await _cargarResumenEntrenamientos();
                         await _checkHcWarning();

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -42,7 +42,6 @@ class _InicioPageState extends ConsumerState<InicioPage> {
   List<Map<String, dynamic>> _entrenamientosMrFit = [];
 
   void _clearDailyStatsData() {
-    _grantedPermissions = {};
     _dataPointsSteps = [];
     _dataPointsWorkout = [];
     _entrenamientosMrFit = [];

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -34,6 +34,7 @@ class _InicioPageState extends ConsumerState<InicioPage> {
   final GlobalKey<State<CalendarWidget>> _calendarKey = GlobalKey<State<CalendarWidget>>();
   final GlobalKey<RefreshIndicatorState> _refreshKey = GlobalKey<RefreshIndicatorState>();
   bool _showHcWarning = true;
+  int _refreshCounter = 0;
 
   // Estados para los datos diarios
   Map<String, bool> _grantedPermissions = {};
@@ -271,7 +272,10 @@ class _InicioPageState extends ConsumerState<InicioPage> {
                     child: RefreshIndicator(
                       key: _refreshKey,
                       onRefresh: () async {
-                        setState(_clearDailyStatsData);
+                        setState(() {
+                          _refreshCounter++;
+                          _clearDailyStatsData();
+                        });
                         _reloadCalendarIfInCurrentWeek(_selectedDate);
                         await _cargarResumenEntrenamientos();
                         await _checkHcWarning();
@@ -320,14 +324,26 @@ class _InicioPageState extends ConsumerState<InicioPage> {
                                   entrenamientosMrFit: _entrenamientosMrFit,
                                 ),
                                 const SizedBox(height: 15),
-                                dailySleepWidget(day: _selectedDate, usuario: usuario),
+                                dailySleepWidget(
+                                  day: _selectedDate,
+                                  usuario: usuario,
+                                  refreshKey: _refreshCounter,
+                                ),
                                 const SizedBox(height: 15),
                                 DailyNutritionWidget(day: _selectedDate, usuario: usuario),
                                 if (usuario.isHealthConnectAvailable) ...[
                                   const SizedBox(height: 15),
-                                  dailyHearthWidget(day: _selectedDate, usuario: usuario),
+                                  dailyHearthWidget(
+                                    day: _selectedDate,
+                                    usuario: usuario,
+                                    refreshKey: _refreshCounter,
+                                  ),
                                   const SizedBox(height: 15),
-                                  dailyVitalsWidget(day: _selectedDate, usuario: usuario),
+                                  dailyVitalsWidget(
+                                    day: _selectedDate,
+                                    usuario: usuario,
+                                    refreshKey: _refreshCounter,
+                                  ),
                                   const SizedBox(height: 15),
                                   dailyPhysicalWidget(usuario: usuario),
                                   const SizedBox(height: 15),

--- a/lib/widgets/common/cached_future_builder.dart
+++ b/lib/widgets/common/cached_future_builder.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+class CachedFutureBuilder<T> extends StatefulWidget {
+  final Future<T> Function() futureBuilder;
+  final Widget Function(BuildContext, AsyncSnapshot<T>) builder;
+  final List<Object?> keys;
+
+  const CachedFutureBuilder({
+    Key? key,
+    required this.futureBuilder,
+    required this.builder,
+    required this.keys,
+  }) : super(key: key);
+
+  @override
+  State<CachedFutureBuilder<T>> createState() => _CachedFutureBuilderState<T>();
+}
+
+class _CachedFutureBuilderState<T> extends State<CachedFutureBuilder<T>> {
+  late Future<T> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = widget.futureBuilder();
+  }
+
+  @override
+  void didUpdateWidget(covariant CachedFutureBuilder<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!listEquals(widget.keys, oldWidget.keys)) {
+      _future = widget.futureBuilder();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<T>(
+      future: _future,
+      builder: widget.builder,
+    );
+  }
+}

--- a/lib/widgets/home/daily_hearth.dart
+++ b/lib/widgets/home/daily_hearth.dart
@@ -10,6 +10,7 @@ Widget dailyHearthWidget({
   required Usuario usuario,
 }) {
   return CachedFutureBuilder<List<HealthDataPoint>>(
+    key: const ValueKey('daily_hearth'),
     futureBuilder: () => usuario.getReadHeartRate(day),
     keys: [day, usuario.id],
     builder: (context, snapshot) {

--- a/lib/widgets/home/daily_hearth.dart
+++ b/lib/widgets/home/daily_hearth.dart
@@ -3,13 +3,15 @@ import 'package:mrfit/utils/colors.dart';
 import 'package:mrfit/models/usuario/usuario.dart';
 import 'package:mrfit/widgets/chart/heart_grafica.dart';
 import 'package:health/health.dart';
+import 'package:mrfit/widgets/common/cached_future_builder.dart';
 
 Widget dailyHearthWidget({
   required DateTime day,
   required Usuario usuario,
 }) {
-  return FutureBuilder<List<HealthDataPoint>>(
-    future: usuario.getReadHeartRate(day),
+  return CachedFutureBuilder<List<HealthDataPoint>>(
+    futureBuilder: () => usuario.getReadHeartRate(day),
+    keys: [day, usuario.id],
     builder: (context, snapshot) {
       final List<HealthDataPoint> heartRatePoints = snapshot.data ?? [];
       Widget content;

--- a/lib/widgets/home/daily_hearth.dart
+++ b/lib/widgets/home/daily_hearth.dart
@@ -8,11 +8,12 @@ import 'package:mrfit/widgets/common/cached_future_builder.dart';
 Widget dailyHearthWidget({
   required DateTime day,
   required Usuario usuario,
+  int refreshKey = 0,
 }) {
   return CachedFutureBuilder<List<HealthDataPoint>>(
     key: const ValueKey('daily_hearth'),
     futureBuilder: () => usuario.getReadHeartRate(day),
-    keys: [day, usuario.id],
+    keys: [day, usuario.id, refreshKey],
     builder: (context, snapshot) {
       final List<HealthDataPoint> heartRatePoints = snapshot.data ?? [];
       Widget content;

--- a/lib/widgets/home/daily_sleep.dart
+++ b/lib/widgets/home/daily_sleep.dart
@@ -4,6 +4,7 @@ import 'package:mrfit/models/usuario/usuario.dart';
 import 'package:mrfit/utils/colors.dart';
 import 'package:mrfit/channel/channel_inactividad.dart';
 import 'package:mrfit/widgets/chart/sleep_bar.dart';
+import 'package:mrfit/widgets/common/cached_future_builder.dart';
 
 Widget _bedtimeIcon() {
   return CircleAvatar(
@@ -18,8 +19,9 @@ Widget dailySleepWidget({required DateTime day, required Usuario usuario}) {
   if (day.hour < horaLevantarse && day.day == DateTime.now().day) {
     return _sleepPlaceholder(usuario);
   }
-  return FutureBuilder<List<SleepSlot>>(
-    future: usuario.getSleepSessionByDate(day),
+  return CachedFutureBuilder<List<SleepSlot>>(
+    futureBuilder: () => usuario.getSleepSessionByDate(day),
+    keys: [day, usuario.id],
     builder: (context, snapshot) {
       if (snapshot.connectionState != ConnectionState.done) {
         return _sleepPlaceholder(usuario);
@@ -27,8 +29,10 @@ Widget dailySleepWidget({required DateTime day, required Usuario usuario}) {
       if (snapshot.data != null && snapshot.data!.isNotEmpty) {
         final firstSlot = snapshot.data!.first;
         final totalMinutes = usuario.calculateTotalMinutes(snapshot.data!);
-        return FutureBuilder<List<SleepSlot>>(
-          future: usuario.getTypeSleepByDate(firstSlot.start, firstSlot.end),
+        return CachedFutureBuilder<List<SleepSlot>>(
+          futureBuilder: () =>
+              usuario.getTypeSleepByDate(firstSlot.start, firstSlot.end),
+          keys: [firstSlot.start, firstSlot.end, usuario.id],
           builder: (ctx2, typeSnap) {
             if (typeSnap.connectionState != ConnectionState.done) {
               return _sleepStats(totalMinutes, firstSlot, "HealthConnect", usuario: usuario);
@@ -46,8 +50,9 @@ Widget dailySleepWidget({required DateTime day, required Usuario usuario}) {
         );
       }
       // rama original de UsageStats
-      return FutureBuilder<List<SleepSlot>>(
-        future: usuario.getSleepSlotsForDay(day),
+      return CachedFutureBuilder<List<SleepSlot>>(
+        futureBuilder: () => usuario.getSleepSlotsForDay(day),
+        keys: [day, usuario.id],
         builder: (context, slotSnapshot) {
           if (slotSnapshot.connectionState != ConnectionState.done) {
             return _sleepPlaceholder(usuario);

--- a/lib/widgets/home/daily_sleep.dart
+++ b/lib/widgets/home/daily_sleep.dart
@@ -20,6 +20,7 @@ Widget dailySleepWidget({required DateTime day, required Usuario usuario}) {
     return _sleepPlaceholder(usuario);
   }
   return CachedFutureBuilder<List<SleepSlot>>(
+    key: const ValueKey('sleep_session'),
     futureBuilder: () => usuario.getSleepSessionByDate(day),
     keys: [day, usuario.id],
     builder: (context, snapshot) {
@@ -30,6 +31,7 @@ Widget dailySleepWidget({required DateTime day, required Usuario usuario}) {
         final firstSlot = snapshot.data!.first;
         final totalMinutes = usuario.calculateTotalMinutes(snapshot.data!);
         return CachedFutureBuilder<List<SleepSlot>>(
+          key: const ValueKey('sleep_type'),
           futureBuilder: () =>
               usuario.getTypeSleepByDate(firstSlot.start, firstSlot.end),
           keys: [firstSlot.start, firstSlot.end, usuario.id],
@@ -51,6 +53,7 @@ Widget dailySleepWidget({required DateTime day, required Usuario usuario}) {
       }
       // rama original de UsageStats
       return CachedFutureBuilder<List<SleepSlot>>(
+        key: const ValueKey('sleep_slots'),
         futureBuilder: () => usuario.getSleepSlotsForDay(day),
         keys: [day, usuario.id],
         builder: (context, slotSnapshot) {

--- a/lib/widgets/home/daily_sleep.dart
+++ b/lib/widgets/home/daily_sleep.dart
@@ -14,7 +14,11 @@ Widget _bedtimeIcon() {
   );
 }
 
-Widget dailySleepWidget({required DateTime day, required Usuario usuario}) {
+Widget dailySleepWidget({
+  required DateTime day,
+  required Usuario usuario,
+  int refreshKey = 0,
+}) {
   int horaLevantarse = usuario.horaFinSueno?.hour ?? 0;
   if (day.hour < horaLevantarse && day.day == DateTime.now().day) {
     return _sleepPlaceholder(usuario);
@@ -22,7 +26,7 @@ Widget dailySleepWidget({required DateTime day, required Usuario usuario}) {
   return CachedFutureBuilder<List<SleepSlot>>(
     key: const ValueKey('sleep_session'),
     futureBuilder: () => usuario.getSleepSessionByDate(day),
-    keys: [day, usuario.id],
+    keys: [day, usuario.id, refreshKey],
     builder: (context, snapshot) {
       if (snapshot.connectionState != ConnectionState.done) {
         return _sleepPlaceholder(usuario);
@@ -34,7 +38,7 @@ Widget dailySleepWidget({required DateTime day, required Usuario usuario}) {
           key: const ValueKey('sleep_type'),
           futureBuilder: () =>
               usuario.getTypeSleepByDate(firstSlot.start, firstSlot.end),
-          keys: [firstSlot.start, firstSlot.end, usuario.id],
+          keys: [firstSlot.start, firstSlot.end, usuario.id, refreshKey],
           builder: (ctx2, typeSnap) {
             if (typeSnap.connectionState != ConnectionState.done) {
               return _sleepStats(totalMinutes, firstSlot, "HealthConnect", usuario: usuario);
@@ -55,7 +59,7 @@ Widget dailySleepWidget({required DateTime day, required Usuario usuario}) {
       return CachedFutureBuilder<List<SleepSlot>>(
         key: const ValueKey('sleep_slots'),
         futureBuilder: () => usuario.getSleepSlotsForDay(day),
-        keys: [day, usuario.id],
+        keys: [day, usuario.id, refreshKey],
         builder: (context, slotSnapshot) {
           if (slotSnapshot.connectionState != ConnectionState.done) {
             return _sleepPlaceholder(usuario);

--- a/lib/widgets/home/daily_vitals.dart
+++ b/lib/widgets/home/daily_vitals.dart
@@ -1,14 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:mrfit/utils/colors.dart';
 import 'package:mrfit/models/usuario/usuario.dart';
+import 'package:mrfit/widgets/common/cached_future_builder.dart';
 
 Widget dailyVitalsWidget({required DateTime day, required Usuario usuario}) {
-  return FutureBuilder<List<dynamic>>(
-    future: Future.wait([
+  return CachedFutureBuilder<List<dynamic>>(
+    futureBuilder: () => Future.wait([
       usuario.getDailySpo2(day),
       usuario.getDailyStress(day),
       usuario.getDailyStairsClimbed(day),
     ]),
+    keys: [day, usuario.id],
     builder: (context, snap) {
       if (snap.connectionState != ConnectionState.done) {
         return const Center(child: CircularProgressIndicator());

--- a/lib/widgets/home/daily_vitals.dart
+++ b/lib/widgets/home/daily_vitals.dart
@@ -5,6 +5,7 @@ import 'package:mrfit/widgets/common/cached_future_builder.dart';
 
 Widget dailyVitalsWidget({required DateTime day, required Usuario usuario}) {
   return CachedFutureBuilder<List<dynamic>>(
+    key: const ValueKey('daily_vitals'),
     futureBuilder: () => Future.wait([
       usuario.getDailySpo2(day),
       usuario.getDailyStress(day),

--- a/lib/widgets/home/daily_vitals.dart
+++ b/lib/widgets/home/daily_vitals.dart
@@ -3,7 +3,11 @@ import 'package:mrfit/utils/colors.dart';
 import 'package:mrfit/models/usuario/usuario.dart';
 import 'package:mrfit/widgets/common/cached_future_builder.dart';
 
-Widget dailyVitalsWidget({required DateTime day, required Usuario usuario}) {
+Widget dailyVitalsWidget({
+  required DateTime day,
+  required Usuario usuario,
+  int refreshKey = 0,
+}) {
   return CachedFutureBuilder<List<dynamic>>(
     key: const ValueKey('daily_vitals'),
     futureBuilder: () => Future.wait([
@@ -11,7 +15,7 @@ Widget dailyVitalsWidget({required DateTime day, required Usuario usuario}) {
       usuario.getDailyStress(day),
       usuario.getDailyStairsClimbed(day),
     ]),
-    keys: [day, usuario.id],
+    keys: [day, usuario.id, refreshKey],
     builder: (context, snap) {
       if (snap.connectionState != ConnectionState.done) {
         return const Center(child: CircularProgressIndicator());


### PR DESCRIPTION
## Summary
- clear daily stats when changing day

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684091ebd08c8333973e6760b5eed88b