### PR TITLE
Fix sleep chart tooltip point

### DIFF
--- a/lib/widgets/chart/sleep_bar.dart
+++ b/lib/widgets/chart/sleep_bar.dart
@@ -82,6 +82,7 @@ class SleepBar extends StatelessWidget {
     DateTime realStart,
     DateTime realEnd,
   ) {
+    const double epsilon = 0.0001; // pequeño desplazamiento para evitar x duplicados
     final List<FlSpot> stepSpots = [];
     if (slots.isEmpty) return stepSpots;
 
@@ -112,10 +113,12 @@ class SleepBar extends StatelessWidget {
       // Si el slot no empieza donde terminó el anterior, agregar transición vertical
       if (stepSpots.isNotEmpty && stepSpots.last.x != startX) {
         stepSpots.add(FlSpot(startX, stepSpots.last.y));
+        // pequeño desplazamiento para el punto vertical
+        stepSpots.add(FlSpot(startX + epsilon, y));
+      } else {
+        stepSpots.add(FlSpot(startX, y));
       }
 
-      // Punto horizontal hasta el final del slot (dentro del rango real)
-      stepSpots.add(FlSpot(startX, y));
       stepSpots.add(FlSpot(endX, y));
     }
 

--- a/lib/widgets/chart/sleep_bar.dart
+++ b/lib/widgets/chart/sleep_bar.dart
@@ -69,6 +69,15 @@ class SleepBar extends StatelessWidget {
     return 'SLEEP_UNKNOWN';
   }
 
+  // Obtiene el tipo de sueño basándose en el valor del eje Y
+  String _getSleepTypeByLevel(double level) {
+    final rounded = level.round();
+    for (final entry in _kTypeValue.entries) {
+      if (entry.value == rounded) return entry.key;
+    }
+    return 'SLEEP_UNKNOWN';
+  }
+
   // Devuelve la etiqueta legible para el tipo de sueño
   String _getSleepTypeLabel(String type) {
     return _kTypeLabel[type] ?? type;
@@ -297,11 +306,7 @@ class SleepBar extends StatelessWidget {
               getTooltipItems: (touchedSpots) {
                 // Añade la hora al final de la etiqueta del tipo de sueño
                 return touchedSpots.map((touchedSpot) {
-                  final sleepType = _getSleepTypeByMinute(
-                    touchedSpot.x,
-                    typeSlots,
-                    graphStart,
-                  );
+                  final sleepType = _getSleepTypeByLevel(touchedSpot.y);
                   final label = _getSleepTypeLabel(sleepType);
                   // Calcula la hora correspondiente al punto seleccionado
                   final pointTime = graphStart.add(Duration(minutes: touchedSpot.x.round()));


### PR DESCRIPTION
## Summary
- adjust sleep line generation to offset vertical points with a small epsilon so tooltips mark the correct value

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b64891fc8333957836001965096e