### PR TITLE
Improve home widgets performance

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -95,6 +95,8 @@ class _InicioPageState extends ConsumerState<InicioPage> {
 
     await Future.wait(futures);
 
+    stopwatch.stop();
+
     // Actualiza los estados locales solo si hay cambios
     if (!mounted) return;
     final elapsed = stopwatch.elapsedMilliseconds;

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -98,7 +98,9 @@ class _InicioPageState extends ConsumerState<InicioPage> {
     // Actualiza los estados locales solo si hay cambios
     if (!mounted) return;
     final elapsed = stopwatch.elapsedMilliseconds;
-    print("Tiempo: ${elapsed}ms");
+    if (kDebugMode) {
+      debugPrint('Tiempo: ${elapsed}ms');
+    }
 
     final bool permissionsChanged =
         !mapEquals(_grantedPermissions, grantedPermissions);

--- a/lib/widgets/home/daily_nutrition.dart
+++ b/lib/widgets/home/daily_nutrition.dart
@@ -38,15 +38,20 @@ class _DailyNutritionWidgetState extends State<DailyNutritionWidget> {
 
   Future<void> _loadCaloricDifference() async {
     final kcal = await widget.usuario.getByDate(widget.day);
+    if (!mounted) return;
     setState(() {
       _currentCalories = kcal?.round() ?? 0;
     });
   }
 
   Future<void> _updateCaloricDifference(int delta) async {
-    setState(() {
+    if (mounted) {
+      setState(() {
+        _currentCalories += delta;
+      });
+    } else {
       _currentCalories += delta;
-    });
+    }
     await widget.usuario.setDiferenciaCalorica(
       widget.day,
       _currentCalories.toDouble(),

--- a/lib/widgets/home/daily_sleep.dart
+++ b/lib/widgets/home/daily_sleep.dart
@@ -7,7 +7,7 @@ import 'package:mrfit/widgets/chart/sleep_bar.dart';
 import 'package:mrfit/widgets/common/cached_future_builder.dart';
 
 Widget _bedtimeIcon() {
-  return CircleAvatar(
+  return const CircleAvatar(
     radius: 16,
     backgroundColor: AppColors.background,
     child: Icon(Icons.bedtime, color: AppColors.accentColor, size: 18),

--- a/lib/widgets/home/daily_trainings.dart
+++ b/lib/widgets/home/daily_trainings.dart
@@ -48,7 +48,7 @@ class DailyTrainingsWidget extends StatefulWidget {
 
 class DailyTrainingsWidgetState extends State<DailyTrainingsWidget> {
   // Se elimina el Padding interno y se retorna directamente el Row
-  Future<Widget> _buildActivityRow({
+  Widget _buildActivityRow({
     required String uuid,
     int? id,
     required String title,
@@ -59,7 +59,7 @@ class DailyTrainingsWidgetState extends State<DailyTrainingsWidget> {
     required Color iconBackgroundColor,
     required String timeInfo,
     String? sourceName,
-  }) async {
+  }) {
     return InkWell(
       onTap: () {
         Navigator.push(
@@ -131,49 +131,37 @@ class DailyTrainingsWidgetState extends State<DailyTrainingsWidget> {
           final index = entry.key;
           final activity = entry.value;
           if (activity['type'] == 'steps') {
-            return FutureBuilder<Widget>(
-              future: _buildActivityRow(
-                uuid: "automatic",
-                title: "Caminar (automático)",
-                start: activity['start'],
-                end: activity['end'],
-                icon: Icons.directions_walk,
-                iconColor: AppColors.mutedAdvertencia,
-                iconBackgroundColor: AppColors.appBarBackground,
-                timeInfo: "${activity['start'].toLocal().toIso8601String().split('T').last.split('.').first.substring(0, 5)} (${activity['durationMin']} min)",
-              ),
-              builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.done && snapshot.hasData) {
-                  final rowWidget = snapshot.data!;
-                  return index == activities.length - 1 ? rowWidget : Padding(padding: const EdgeInsets.only(bottom: 10), child: rowWidget);
-                }
-                return const SizedBox(height: 50);
-              },
+            final rowWidget = _buildActivityRow(
+              uuid: "automatic",
+              title: "Caminar (automático)",
+              start: activity['start'],
+              end: activity['end'],
+              icon: Icons.directions_walk,
+              iconColor: AppColors.mutedAdvertencia,
+              iconBackgroundColor: AppColors.appBarBackground,
+              timeInfo: "${activity['start'].toLocal().toIso8601String().split('T').last.split('.').first.substring(0, 5)} (${activity['durationMin']} min)",
             );
+            return index == activities.length - 1
+                ? rowWidget
+                : Padding(padding: const EdgeInsets.only(bottom: 10), child: rowWidget);
           } else if (activity['type'] == 'workout') {
             final info = ModeloDatos().getActivityTypeDetails(activity['activityType']);
             final duration = (activity['end'] as DateTime).difference(activity['start'] as DateTime).inMinutes;
-            return FutureBuilder<Widget>(
-              future: _buildActivityRow(
-                uuid: activity['uuid'] ?? "",
-                id: activity['id'] ?? 0,
-                title: activity["title"] ?? info["nombre"],
-                start: activity['start'],
-                end: activity['end'],
-                icon: info["icon"],
-                iconColor: AppColors.mutedAdvertencia,
-                iconBackgroundColor: AppColors.appBarBackground,
-                timeInfo: "${activity['start'].toLocal().toIso8601String().split('T').last.split('.').first.substring(0, 5)} ($duration min)",
-                sourceName: activity['sourceName'],
-              ),
-              builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.done && snapshot.hasData) {
-                  final rowWidget = snapshot.data!;
-                  return index == activities.length - 1 ? rowWidget : Padding(padding: const EdgeInsets.only(bottom: 10), child: rowWidget);
-                }
-                return const SizedBox(height: 50);
-              },
+            final rowWidget = _buildActivityRow(
+              uuid: activity['uuid'] ?? "",
+              id: activity['id'] ?? 0,
+              title: activity["title"] ?? info["nombre"],
+              start: activity['start'],
+              end: activity['end'],
+              icon: info["icon"],
+              iconColor: AppColors.mutedAdvertencia,
+              iconBackgroundColor: AppColors.appBarBackground,
+              timeInfo: "${activity['start'].toLocal().toIso8601String().split('T').last.split('.').first.substring(0, 5)} ($duration min)",
+              sourceName: activity['sourceName'],
             );
+            return index == activities.length - 1
+                ? rowWidget
+                : Padding(padding: const EdgeInsets.only(bottom: 10), child: rowWidget);
           }
           return const SizedBox.shrink();
         }).toList(),


### PR DESCRIPTION
## Summary
- simplify home debug print
- avoid unnecessary FutureBuilder in DailyTrainingsWidget
- guard `DailyNutritionWidget` state updates after async operations
- make `_bedtimeIcon` const

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840baade58c8333a06a087216a9e1bd