### PR TITLE
Improve background step recording

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:mrfit/providers/usuario_provider.dart';
 import 'package:mrfit/utils/colors.dart';
 import 'package:mrfit/screens/home.dart';
 import 'package:mrfit/screens/usuario/usuario_config.dart';
+import 'package:mrfit/providers/walking_provider.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -78,12 +79,13 @@ class MyApp extends ConsumerWidget {
 }
 
 /// Scaffold común con AppBar
-class HomeShell extends StatelessWidget {
+class HomeShell extends ConsumerWidget {
   final Widget body;
   const HomeShell({super.key, required this.body});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isWalking = ref.watch(walkingProvider);
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
@@ -97,6 +99,12 @@ class HomeShell extends StatelessWidget {
           ),
         ),
         actions: [
+          if (isWalking)
+            const Padding(
+              padding: EdgeInsets.only(right: 8.0),
+              child: Icon(Icons.directions_walk,
+                  color: AppColors.mutedAdvertencia),
+            ),
           IconButton(
             icon: const Icon(Icons.settings),
             onPressed: () {

--- a/lib/providers/walking_provider.dart
+++ b/lib/providers/walking_provider.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Indicates whether the user is currently walking according to the
+/// pedometer status stream.
+final walkingProvider = StateProvider<bool>((ref) => false);

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -22,6 +22,7 @@ import 'package:mrfit/widgets/home/daily_hearth.dart';
 import 'package:mrfit/widgets/home/daily_statistics.dart';
 import 'package:mrfit/widgets/home/daily_vitals.dart';
 import 'package:mrfit/services/step_counter_service.dart';
+import 'package:mrfit/providers/walking_provider.dart';
 import 'package:mrfit/screens/estadisticas/actividad_page.dart';
 
 class InicioPage extends ConsumerStatefulWidget {
@@ -127,14 +128,17 @@ class _InicioPageState extends ConsumerState<InicioPage> {
       _stepCounterService = StepCounterService(
         usuario: usuario,
         onError: (error) => print("Error en el podómetro: $error"),
+        onStatusChanged: (walking) =>
+            ref.read(walkingProvider.notifier).state = walking,
       );
-      _stepCounterService!.start();
+      Future.microtask(() => _stepCounterService!.start());
     }
   }
 
   @override
   void dispose() {
     _stepCounterService?.dispose();
+    ref.read(walkingProvider.notifier).state = false;
     super.dispose();
   }
 

--- a/lib/services/step_counter_service.dart
+++ b/lib/services/step_counter_service.dart
@@ -1,47 +1,90 @@
 import 'dart:async';
+import 'dart:convert';
 import 'package:pedometer/pedometer.dart';
 import 'package:mrfit/models/usuario/usuario.dart';
+import 'package:mrfit/models/cache/custom_cache.dart';
 
 /// Servicio dedicado a gestionar el conteo de pasos y su registro.
 /// Agrupa los pasos y los inserta periódicamente para optimizar recursos.
 class StepCounterService {
   static const Duration _batchDuration = Duration(minutes: 1);
+  static const String _cacheKey = 'step_counter_last';
 
   final Usuario usuario;
   final void Function(dynamic error)? onError;
+  final void Function(bool walking)? onStatusChanged;
 
   StreamSubscription<StepCount>? _stepCountSub;
+  StreamSubscription<PedestrianStatus>? _statusSub;
   Timer? _flushTimer;
   int _lastStepsValue = 0;
   DateTime? _lastStepTime;
+  bool _isWalking = false;
+  bool get isWalking => _isWalking;
 
   int _pendingSteps = 0;
   DateTime? _pendingStartTime;
   DateTime? _pendingEndTime;
 
+  Future<void> _loadLastInfo() async {
+    final cache = await CustomCache.getByKey(_cacheKey);
+    if (cache != null) {
+      try {
+        final data = jsonDecode(cache.value) as Map<String, dynamic>;
+        _lastStepsValue = data['value'] as int? ?? 0;
+        final timeStr = data['time'] as String?;
+        if (timeStr != null && timeStr.isNotEmpty) {
+          _lastStepTime = DateTime.tryParse(timeStr);
+        }
+      } catch (_) {}
+    }
+  }
+
+  Future<void> _persistLastInfo() async {
+    await CustomCache.set(
+      _cacheKey,
+      jsonEncode({
+        'value': _lastStepsValue,
+        'time': _lastStepTime?.toIso8601String() ?? '',
+      }),
+    );
+  }
+
   StepCounterService({
     required this.usuario,
     this.onError,
+    this.onStatusChanged,
   });
 
-  void start() {
+  Future<void> start() async {
+    await _loadLastInfo();
     _stepCountSub = Pedometer.stepCountStream.listen(
       _onStepCount,
       onError: onError,
+    );
+    _statusSub = Pedometer.pedestrianStatusStream.listen(
+      _onPedestrianStatus,
+      onError: (_) {},
     );
     _flushTimer = Timer.periodic(_batchDuration, (_) => _flushSteps());
   }
 
   void _onStepCount(StepCount event) {
-    int currentSteps = event.steps;
-    DateTime timestamp = event.timeStamp;
+    final currentSteps = event.steps;
+    final timestamp = event.timeStamp;
 
     if (_lastStepTime == null) {
       _lastStepsValue = currentSteps;
       _lastStepTime = timestamp;
       return;
     }
+
     int newSteps = currentSteps - _lastStepsValue;
+    if (newSteps < 0) {
+      // El contador se reinició (posible reinicio del dispositivo)
+      newSteps = currentSteps;
+      _pendingStartTime = timestamp;
+    }
     if (newSteps > 0) {
       _pendingSteps += newSteps;
       _pendingStartTime ??= _lastStepTime;
@@ -58,11 +101,20 @@ class StepCounterService {
       _pendingStartTime = null;
       _pendingEndTime = null;
     }
+    _persistLastInfo();
+  }
+
+  void _onPedestrianStatus(PedestrianStatus status) {
+    final walking = status == PedestrianStatus.walking;
+    _isWalking = walking;
+    onStatusChanged?.call(walking);
   }
 
   void dispose() {
     _stepCountSub?.cancel();
+    _statusSub?.cancel();
     _flushTimer?.cancel();
     _flushSteps();
+    _persistLastInfo();
   }
 }


### PR DESCRIPTION
## Summary
- save last pedometer reading in `CustomCache`
- restore previous reading when service starts again
- protect step counter for reboots and persist data when flushing
- launch the service asynchronously from `InicioPage`
- publish walking status via provider and show an icon in the AppBar when walking

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847df7bb0108333953262235fac29e1