### PR TITLE
Fix BuildContext lints

### DIFF
--- a/lib/screens/ejercicios/detalle/ejercicio_detalle_resumen.dart
+++ b/lib/screens/ejercicios/detalle/ejercicio_detalle_resumen.dart
@@ -208,18 +208,19 @@ class EjercicioResumen extends StatelessWidget {
               child: IconButton(
                 icon: const FaIcon(FontAwesomeIcons.youtube, color: AppColors.mutedRed, size: 32),
                 tooltip: 'Buscar en YouTube',
-                onPressed: () async {
-                  // Usa el nombre del ejercicio para la búsqueda
-                  final query = Uri.encodeComponent(ejercicio.nombre);
-                  final url = 'https://www.youtube.com/results?search_query=$query';
-                  try {
-                    await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
-                  } catch (_) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('No se pudo abrir YouTube')),
-                    );
-                  }
-                },
+                  onPressed: () async {
+                    // Usa el nombre del ejercicio para la búsqueda
+                    final query = Uri.encodeComponent(ejercicio.nombre);
+                    final url = 'https://www.youtube.com/results?search_query=$query';
+                    try {
+                      await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+                    } catch (_) {
+                      if (!context.mounted) return;
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('No se pudo abrir YouTube')),
+                      );
+                    }
+                  },
               ),
             ),
           ],

--- a/lib/screens/rutinas/rutinas_page.dart
+++ b/lib/screens/rutinas/rutinas_page.dart
@@ -154,12 +154,13 @@ class _RutinasPageState extends ConsumerState<RutinasPage> {
           return;
         }
         // Navegación diferida para evitar el lock del Navigator.
-        Future.microtask(() {
-          Navigator.of(context).pushAndRemoveUntil(
-            MaterialPageRoute(builder: (_) => const MyApp()),
-            (route) => false,
-          );
-        });
+          final navigator = Navigator.of(context);
+          Future.microtask(() {
+            navigator.pushAndRemoveUntil(
+              MaterialPageRoute(builder: (_) => const MyApp()),
+              (route) => false,
+            );
+          });
         // No se cierra la app, se redirige a la raíz.
       },
       child: Scaffold(

--- a/lib/screens/usuario/configuracion/config_app.dart
+++ b/lib/screens/usuario/configuracion/config_app.dart
@@ -9,6 +9,7 @@ import 'package:mrfit/models/usuario/usuario_backup.dart';
 class ConfiguracionApp {
   static Future<void> openFTPConfig(BuildContext context) async {
     final prefs = await SharedPreferences.getInstance();
+    if (!context.mounted) return;
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => _FTPConfigScreen(prefs: prefs),
@@ -44,6 +45,7 @@ class ConfiguracionApp {
     );
 
     final backupFiles = await UsuarioBackup.listarBackups();
+    if (!context.mounted) return;
 
     Navigator.of(rootCtx).pop();
 
@@ -112,6 +114,7 @@ class ConfiguracionApp {
                                 if (ok) {
                                   setState(() => backupFiles.remove(fileName));
                                 } else {
+                                  if (!ctx2.mounted) return;
                                   showDialog(
                                     context: ctx2,
                                     builder: (_) => AlertDialog(
@@ -145,7 +148,7 @@ class ConfiguracionApp {
       },
     );
 
-    if (selectedFile == null) {
+    if (selectedFile == null || !context.mounted) {
       return;
     }
 
@@ -171,7 +174,7 @@ class ConfiguracionApp {
         ],
       ),
     );
-    if (confirmImport != true) {
+    if (confirmImport != true || !context.mounted) {
       return;
     }
 
@@ -193,6 +196,7 @@ class ConfiguracionApp {
     );
 
     final exito = await UsuarioBackup.importarBackupSeleccionado(context, selectedFile);
+    if (!context.mounted) return;
 
     Navigator.of(rootCtx).pop();
 


### PR DESCRIPTION
## Summary
- avoid using BuildContext after async gaps in `ejercicio_detalle_resumen.dart`
- remove async BuildContext usage in `rutinas_page.dart`
- add mounted checks in `config_app.dart`

## Testing
- `flutter analyze`
- `flutter test` *(fails: Muestra InicioPage cuando HealthConnect está disponible)*

------
https://chatgpt.com/codex/tasks/task_e_685131b09f6c833392dc6c6e7c285e63